### PR TITLE
Updated build.gradle to work with latest tools

### DIFF
--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -15,11 +15,13 @@ repositories {
     jcenter()
 }
 
+ext.versions = [supportLibVersion: "24.2.0"]
+
 dependencies {
-    compile "com.android.support:support-v4:24.2.0"
-    compile "com.android.support:support-v13:24.2.0"
-    compile "com.android.support:cardview-v7:24.2.0"
-    compile "com.android.support:appcompat-v7:24.2.0"
+    compile "com.android.support:support-v4:$versions.supportLibVersion"
+    compile "com.android.support:support-v13:$versions.supportLibVersion"
+    compile "com.android.support:cardview-v7:$versions.supportLibVersion"
+    compile "com.android.support:appcompat-v7:$versions.supportLibVersion"
 }
 
 // The sample build uses multiple directories to

--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }
 
@@ -16,10 +16,10 @@ repositories {
 }
 
 dependencies {
-    compile "com.android.support:support-v4:24.1.1"
-    compile "com.android.support:support-v13:24.1.1"
-    compile "com.android.support:cardview-v7:24.1.1"
-    compile "com.android.support:appcompat-v7:24.1.1"
+    compile "com.android.support:support-v4:24.2.0"
+    compile "com.android.support:support-v13:24.2.0"
+    compile "com.android.support:cardview-v7:24.2.0"
+    compile "com.android.support:appcompat-v7:24.2.0"
 }
 
 // The sample build uses multiple directories to
@@ -32,7 +32,7 @@ List<String> dirs = [
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.1"
+    buildToolsVersion "24.0.2"
 
     defaultConfig {
         minSdkVersion 19

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Pre-requisites
 --------------
 
 - Android SDK 24
-- Android Build Tools v24.0.1
+- Android Build Tools v24.0.2
 - Android Support Repository
 
 Getting Started

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 02 15:37:05 PST 2014
+#Tue Sep 13 16:30:26 CDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
Updated to use tools `2.1.3`, support lib `24.2.0` and gradle `2.14.1`
